### PR TITLE
bugfix/call_script_from_anywhere

### DIFF
--- a/scm_modules/__init__.py
+++ b/scm_modules/__init__.py
@@ -1,2 +1,2 @@
 # version of the scm-package
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/scm_modules/__main__.py
+++ b/scm_modules/__main__.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 from scm_modules.metrics import main_sequence, distance_ia
 from scm_modules.utils import ProgrammingLanguageConfig

--- a/scm_modules/__main__.py
+++ b/scm_modules/__main__.py
@@ -1,13 +1,8 @@
 import argparse
 import sys
 
-# make main-sequence script visible
-sys.path.append('scm_modules/metrics/')
-from main_sequence import MainSequence
-from distance_ia import DistanceIA
-
-sys.path.append('scm_modules/utils/')
-import ProgrammingLanguageConfig as plc
+from scm_modules.metrics import main_sequence, distance_ia
+from scm_modules.utils import ProgrammingLanguageConfig
 
 
 def main():
@@ -41,11 +36,11 @@ def main():
     save_metric_path = args['save_path']
 
     # set chosen programming language
-    plc.PROGRAMMING_LANGUAGE = prog_lang
+    ProgrammingLanguageConfig.PROGRAMMING_LANGUAGE = prog_lang
 
     # start respective application
     if show_distance:
-        dist = DistanceIA(dir_path)
+        dist = distance_ia.DistanceIA(dir_path)
         dist.plot_distance()
 
         # save metric if desired
@@ -53,7 +48,7 @@ def main():
             dist.save_metric(save_metric_path if save_metric_path is not None else '')
 
     elif show_main_sequence:
-        main_seq = MainSequence(dir_path)
+        main_seq = main_sequence.MainSequence(dir_path)
         main_seq.plot_metrics()
 
         # save metric if desired

--- a/scm_modules/metrics/__init__.py
+++ b/scm_modules/metrics/__init__.py
@@ -1,0 +1,2 @@
+# version of the metrics-package
+__version__ = "1.0.2"

--- a/scm_modules/metrics/abstractness_metric.py
+++ b/scm_modules/metrics/abstractness_metric.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import re
-import sys
 import warnings
 
 from scm_modules.utils import FileUtility, ProgrammingLanguageConfig

--- a/scm_modules/metrics/abstractness_metric.py
+++ b/scm_modules/metrics/abstractness_metric.py
@@ -3,10 +3,7 @@ import re
 import sys
 import warnings
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import FileUtility as fut
-import ProgrammingLanguageConfig as plc
+from scm_modules.utils import FileUtility, ProgrammingLanguageConfig
 
 
 class AbstractnessMetric:
@@ -40,25 +37,25 @@ class AbstractnessMetric:
                             class_definition_found = False
 
                     # find namespace
-                    if re.match(plc.get_namespace_identifier(), line):
+                    if re.match(ProgrammingLanguageConfig.get_namespace_identifier(), line):
                         counter_namespaces += 1
 
                     # find class
-                    if re.match(plc.get_class_identifier(), line):
+                    if re.match(ProgrammingLanguageConfig.get_class_identifier(), line):
                         # indicate inside class definition
                         class_definition_found = True
                         nb_classes += 1
 
                     # find one abstract method
                     if class_definition_found:
-                        if re.match(plc.get_abstract_method_identifier(), line):
+                        if re.match(ProgrammingLanguageConfig.get_abstract_method_identifier(), line):
                             # one virtual = 0 method is sufficient for an abstract class
                             nb_interfaces += 1
                             class_definition_found = False
 
         except FileNotFoundError as ex:
             warnings.warn('{} ...returning default values'.format(ex))
-        except plc.LanguageOptionError as ex:
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
             warnings.warn(ex.args)
 
         return nb_interfaces, nb_classes
@@ -69,7 +66,7 @@ class AbstractnessMetric:
             nb_interfaces, nb_classes = self._get_number_of_interfaces_and_classes_of_file(file)
 
             # add amount of interfaces and classes to matrix
-            self._interface_class_matrix[fut.extract_filename(file)] = [nb_interfaces, nb_classes]
+            self._interface_class_matrix[FileUtility.extract_filename(file)] = [nb_interfaces, nb_classes]
 
     def _calculate_abstractness_for_each_file(self):
         ''' calculate the abstractness metric using A = Na / Nc:
@@ -101,11 +98,11 @@ class AbstractnessMetric:
         3) calculate the abstractness metric '''
         allowed_file_extensions = []
         try:
-            allowed_file_extensions = plc.get_file_extensions_am()
-        except plc.LanguageOptionError as ex:
+            allowed_file_extensions = ProgrammingLanguageConfig.get_file_extensions_am()
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
             warnings.warn(ex.args)
 
-        self._list_of_files = fut.get_all_code_files(self._dir_path, allowed_file_extensions)
+        self._list_of_files = FileUtility.get_all_code_files(self._dir_path, allowed_file_extensions)
         self._search_files_for_interfaces()
         abstractness_metric = self._calculate_abstractness_for_each_file()
 

--- a/scm_modules/metrics/distance_ia.py
+++ b/scm_modules/metrics/distance_ia.py
@@ -2,10 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import sys
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import DataSeriesUtility as dsu
-import FileUtility as fut
+from scm_modules.utils import DataSeriesUtility, FileUtility
 
 
 class DistanceIA:
@@ -29,7 +26,7 @@ class DistanceIA:
         ''' show a diagram picturing the distance in each components, where
         - y-axis denotes the distance
         - x-axis denotes the different files/components '''
-        self._instability_metric, self._abstractness_metric = dsu.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
         self._calculate_distance()
 
         ind = np.arange(self._distance.size)
@@ -48,4 +45,4 @@ class DistanceIA:
             self._calculate_distance()
 
         # save it
-        fut.save_metric_to_file(self._distance, dir_path)
+        FileUtility.save_metric_to_file(self._distance, dir_path)

--- a/scm_modules/metrics/distance_ia.py
+++ b/scm_modules/metrics/distance_ia.py
@@ -25,7 +25,8 @@ class DistanceIA:
         ''' show a diagram picturing the distance in each components, where
         - y-axis denotes the distance
         - x-axis denotes the different files/components '''
-        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric =
+            DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
         self._calculate_distance()
 
         ind = np.arange(self._distance.size)

--- a/scm_modules/metrics/distance_ia.py
+++ b/scm_modules/metrics/distance_ia.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import sys
 
 from scm_modules.utils import DataSeriesUtility, FileUtility
 

--- a/scm_modules/metrics/distance_ia.py
+++ b/scm_modules/metrics/distance_ia.py
@@ -25,7 +25,7 @@ class DistanceIA:
         ''' show a diagram picturing the distance in each components, where
         - y-axis denotes the distance
         - x-axis denotes the different files/components '''
-        self._instability_metric, self._abstractness_metric =
+        self._instability_metric, self._abstractness_metric = \
             DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
         self._calculate_distance()
 

--- a/scm_modules/metrics/instability_metric.py
+++ b/scm_modules/metrics/instability_metric.py
@@ -22,12 +22,12 @@ class InstabilityMetric:
                 for line in file:
                     if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
                         # ignore ending " to get the pure filename
-                        include_filename =
+                        include_filename = \
                             line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
                         user_include_list.append(include_filename)
                     elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
                         # ignore ending > to get the pure filename
-                        include_filename =
+                        include_filename = \
                             line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
                         stl_include_list.append(include_filename)
 

--- a/scm_modules/metrics/instability_metric.py
+++ b/scm_modules/metrics/instability_metric.py
@@ -3,10 +3,7 @@ import pandas as pd
 import sys
 import warnings
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import FileUtility as fut
-import ProgrammingLanguageConfig as plc
+from scm_modules.utils import FileUtility, ProgrammingLanguageConfig
 
 
 class InstabilityMetric:
@@ -24,18 +21,18 @@ class InstabilityMetric:
         try:
             with open(file_path, 'r') as file:
                 for line in file:
-                    if line.startswith(plc.get_prefix_user_include_identifier()):
+                    if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
                         # ignore ending " to get the pure filename
-                        include_filename = line[len(plc.get_prefix_user_include_identifier()):].strip()[:-1]
+                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
                         user_include_list.append(include_filename)
-                    elif line.startswith(plc.get_prefix_standard_include_identifier()):
+                    elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
                         # ignore ending > to get the pure filename
-                        include_filename = line[len(plc.get_prefix_standard_include_identifier()):].strip()[:-1]
+                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
                         stl_include_list.append(include_filename)
 
         except FileNotFoundError as ex:
             warnings.warn('{} ...returning default values'.format(ex))
-        except plc.LanguageOptionError as ex:
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
             warnings.warn(ex.args)
 
         return user_include_list, stl_include_list
@@ -44,7 +41,7 @@ class InstabilityMetric:
         ''' create a 2D matrix with dim = m x n, where m is the number of user-included files '''
         m = len(self._list_of_user_files)
         null_matrix = np.zeros((m, m), dtype=int)
-        names = [fut.extract_filename(filepath) for filepath in self._list_of_user_files]
+        names = [FileUtility.extract_filename(filepath) for filepath in self._list_of_user_files]
         self._include_matrix = pd.DataFrame(null_matrix, index=names, columns=names)
 
     def _fill_include_matrix(self):
@@ -53,7 +50,7 @@ class InstabilityMetric:
         # check includes
         for filepath in self._list_of_user_files:
             # get filename which includes the following files
-            including_file = fut.extract_filename(filepath)
+            including_file = FileUtility.extract_filename(filepath)
 
             # get list of user-includes
             user_includes, stl_includes = self._get_includes_of_file(filepath)
@@ -122,11 +119,11 @@ class InstabilityMetric:
         ''' encapsulate all methods necessary to compute the instability values for each component '''
         allowed_file_extensions = []
         try:
-            allowed_file_extensions = plc.get_file_extensions_im()
-        except plc.LanguageOptionError as ex:
+            allowed_file_extensions = ProgrammingLanguageConfig.get_file_extensions_im()
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
             warnings.warn(ex.args)
 
-        self._list_of_user_files = fut.get_all_code_files(self._dir_path, allowed_file_extensions)
+        self._list_of_user_files = FileUtility.get_all_code_files(self._dir_path, allowed_file_extensions)
         self._create_user_include_matrix()
         self._add_stl_includes()
         self._fill_include_matrix()

--- a/scm_modules/metrics/instability_metric.py
+++ b/scm_modules/metrics/instability_metric.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import warnings
 
-from scm_modules.utils import FileUtility, ProgrammingLanguageConfig as plc
+from scm_modules.utils import FileUtility, ProgrammingLanguageConfig
 
 
 class InstabilityMetric:

--- a/scm_modules/metrics/instability_metric.py
+++ b/scm_modules/metrics/instability_metric.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import sys
 import warnings
 
 from scm_modules.utils import FileUtility, ProgrammingLanguageConfig

--- a/scm_modules/metrics/instability_metric.py
+++ b/scm_modules/metrics/instability_metric.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import warnings
 
-from scm_modules.utils import FileUtility, ProgrammingLanguageConfig
+from scm_modules.utils import FileUtility, ProgrammingLanguageConfig as plc
 
 
 class InstabilityMetric:
@@ -22,11 +22,13 @@ class InstabilityMetric:
                 for line in file:
                     if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
                         # ignore ending " to get the pure filename
-                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
+                        include_filename =
+                            line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
                         user_include_list.append(include_filename)
                     elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
                         # ignore ending > to get the pure filename
-                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
+                        include_filename =
+                            line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
                         stl_include_list.append(include_filename)
 
         except FileNotFoundError as ex:

--- a/scm_modules/metrics/main_sequence.py
+++ b/scm_modules/metrics/main_sequence.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 import numpy as np
-import sys
 import warnings
 
 from scm_modules.utils import DataSeriesUtility, FileUtility

--- a/scm_modules/metrics/main_sequence.py
+++ b/scm_modules/metrics/main_sequence.py
@@ -111,7 +111,8 @@ class MainSequence:
         ''' show a diagram picturing the Main Sequence, where
         - y-axis denotes the Abstractness
         - x-axis denotes the Instability '''
-        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric =
+            DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # create basic layout format
         ax = self._layout_ax()
@@ -132,7 +133,8 @@ class MainSequence:
         ''' save both metrics to directory. If provided use user-defined directory '''
         # if not already computed get metrics
         if self._instability_metric is None or self._abstractness_metric is None:
-            self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+            self._instability_metric, self._abstractness_metric =
+                DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # save them
         FileUtility.save_metric_to_file(self._instability_metric, dir_path)

--- a/scm_modules/metrics/main_sequence.py
+++ b/scm_modules/metrics/main_sequence.py
@@ -3,10 +3,7 @@ import numpy as np
 import sys
 import warnings
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import DataSeriesUtility as dsu
-import FileUtility as fut
+from scm_modules.utils import DataSeriesUtility, FileUtility
 
 
 class MainSequence:
@@ -115,7 +112,7 @@ class MainSequence:
         ''' show a diagram picturing the Main Sequence, where
         - y-axis denotes the Abstractness
         - x-axis denotes the Instability '''
-        self._instability_metric, self._abstractness_metric = dsu.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # create basic layout format
         ax = self._layout_ax()
@@ -136,8 +133,8 @@ class MainSequence:
         ''' save both metrics to directory. If provided use user-defined directory '''
         # if not already computed get metrics
         if self._instability_metric is None or self._abstractness_metric is None:
-            self._instability_metric, self._abstractness_metric = dsu.get_instability_and_abstractness_metric(self._dir_path)
+            self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # save them
-        fut.save_metric_to_file(self._instability_metric, dir_path)
-        fut.save_metric_to_file(self._abstractness_metric, dir_path)
+        FileUtility.save_metric_to_file(self._instability_metric, dir_path)
+        FileUtility.save_metric_to_file(self._abstractness_metric, dir_path)

--- a/scm_modules/metrics/main_sequence.py
+++ b/scm_modules/metrics/main_sequence.py
@@ -111,7 +111,7 @@ class MainSequence:
         ''' show a diagram picturing the Main Sequence, where
         - y-axis denotes the Abstractness
         - x-axis denotes the Instability '''
-        self._instability_metric, self._abstractness_metric =
+        self._instability_metric, self._abstractness_metric = \
             DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # create basic layout format
@@ -133,7 +133,7 @@ class MainSequence:
         ''' save both metrics to directory. If provided use user-defined directory '''
         # if not already computed get metrics
         if self._instability_metric is None or self._abstractness_metric is None:
-            self._instability_metric, self._abstractness_metric =
+            self._instability_metric, self._abstractness_metric = \
                 DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # save them

--- a/scm_modules/utils/DataSeriesUtility.py
+++ b/scm_modules/utils/DataSeriesUtility.py
@@ -1,10 +1,8 @@
 import pandas as pd
 import sys
 
-# make metric scripts visible
-sys.path.append('scm_modules/metrics/')
-from instability_metric import InstabilityMetric
-from abstractness_metric import AbstractnessMetric
+from scm_modules.metrics.instability_metric import InstabilityMetric
+from scm_modules.metrics.abstractness_metric import AbstractnessMetric
 
 
 # default value used to pad data-sequences to required size

--- a/scm_modules/utils/DataSeriesUtility.py
+++ b/scm_modules/utils/DataSeriesUtility.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import sys
 
 from scm_modules.metrics.instability_metric import InstabilityMetric
 from scm_modules.metrics.abstractness_metric import AbstractnessMetric

--- a/scm_modules/utils/ProgrammingLanguageConfig.py
+++ b/scm_modules/utils/ProgrammingLanguageConfig.py
@@ -1,4 +1,4 @@
-import ProgrammingLanguageConstants as plconst
+from scm_modules.utils import ProgrammingLanguageConstants
 
 PROGRAMMING_LANGUAGE = ''
 
@@ -18,21 +18,21 @@ class LanguageOptionError(RuntimeError):
 
 def get_file_extensions_im():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_ALLOWED_FILE_EXTENSIONS_IM
+        return ProgrammingLanguageConstants.CPP_ALLOWED_FILE_EXTENSIONS_IM
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
 
 def get_file_extensions_am():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_ALLOWED_FILE_EXTENSIONS_AM
+        return ProgrammingLanguageConstants.CPP_ALLOWED_FILE_EXTENSIONS_AM
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
 
 def get_class_identifier():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_CLASS_IDENTIFIER
+        return ProgrammingLanguageConstants.CPP_CLASS_IDENTIFIER
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
@@ -46,27 +46,27 @@ def get_interface_identifier():
 
 def get_abstract_method_identifier():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_ABSTRACT_METHOD_IDENTIFIER
+        return ProgrammingLanguageConstants.CPP_ABSTRACT_METHOD_IDENTIFIER
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
 
 def get_namespace_identifier():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_NAMESPACE_IDENTIFIER
+        return ProgrammingLanguageConstants.CPP_NAMESPACE_IDENTIFIER
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
 
 def get_prefix_user_include_identifier():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_PREFIX_USER_INCLUDE
+        return ProgrammingLanguageConstants.CPP_PREFIX_USER_INCLUDE
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
 
 
 def get_prefix_standard_include_identifier():
     if PROGRAMMING_LANGUAGE == 'c++':
-        return plconst.CPP_PREFIX_STD_INCLUDE
+        return ProgrammingLanguageConstants.CPP_PREFIX_STD_INCLUDE
     else:
         raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))

--- a/scm_modules/utils/__init__.py
+++ b/scm_modules/utils/__init__.py
@@ -1,0 +1,2 @@
+# version of the utils.package
+__version__ = "1.0.2"

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ setup(
     author='Markus Loipfinger',
     author_email='m.loipfinger@hotmail.de',
     url='https://github.com/Markus2101/StaticCodeMetrics',
-    version='1.0.1',
+    version='1.0.2',
     license='GPL-3.0',
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
     ],
-    packages=['scm_modules', 'scm_modules/metrics', 'scm_modules/utils'],
+    packages=['scm_modules', 'scm_modules.metrics', 'scm_modules.utils'],
     install_requires=['numpy', 'pandas', 'matplotlib'],
     entry_points={'console_scripts': ['staticcodemetric=scm_modules.__main__:main']}
 )

--- a/tests/modules_under_test/metrics/abstractness_metric.py
+++ b/tests/modules_under_test/metrics/abstractness_metric.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import re
+import warnings
+
+import sys
+sys.path.append('tests/modules_under_test/')
+from utils import FileUtility, ProgrammingLanguageConfig
+
+
+class AbstractnessMetric:
+    def __init__(self, dir_path):
+        self._dir_path = dir_path
+        self._interface_class_matrix = pd.DataFrame(index=['N_a', 'N_c'], dtype=int)
+        self._list_of_files = []
+
+    def _get_number_of_interfaces_and_classes_of_file(self, file_path):  # noqa: C901
+        ''' return the number of interfaces or classes present in given file.
+        In C++, interfaces/abstract classes are defined using the virtual-keyword and/or one or more
+        method equal to 0 (virtual void methodX() = 0;
+        Info: an interface/abstract class also counts to the total amount of classes '''
+        nb_interfaces = 0
+        nb_classes = 0
+        class_definition_found = False
+        counter_namespaces = 0
+        counter_curly_braces = 0
+
+        try:
+            with open(file_path, 'r') as file:
+                for line in file:
+                    # increment / decrement counter for curly braces
+                    if '{' in line:
+                        counter_curly_braces += 1
+
+                    if '}' in line:
+                        counter_curly_braces -= 1
+                        # check for end of class and reset flag
+                        if counter_curly_braces == counter_namespaces:
+                            class_definition_found = False
+
+                    # find namespace
+                    if re.match(ProgrammingLanguageConfig.get_namespace_identifier(), line):
+                        counter_namespaces += 1
+
+                    # find class
+                    if re.match(ProgrammingLanguageConfig.get_class_identifier(), line):
+                        # indicate inside class definition
+                        class_definition_found = True
+                        nb_classes += 1
+
+                    # find one abstract method
+                    if class_definition_found:
+                        if re.match(ProgrammingLanguageConfig.get_abstract_method_identifier(), line):
+                            # one virtual = 0 method is sufficient for an abstract class
+                            nb_interfaces += 1
+                            class_definition_found = False
+
+        except FileNotFoundError as ex:
+            warnings.warn('{} ...returning default values'.format(ex))
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
+            warnings.warn(ex.args)
+
+        return nb_interfaces, nb_classes
+
+    def _search_files_for_interfaces(self):
+        ''' iterate through all files and get their interfaces / abstract class definitons '''
+        for file in self._list_of_files:
+            nb_interfaces, nb_classes = self._get_number_of_interfaces_and_classes_of_file(file)
+
+            # add amount of interfaces and classes to matrix
+            self._interface_class_matrix[FileUtility.extract_filename(file)] = [nb_interfaces, nb_classes]
+
+    def _calculate_abstractness_for_each_file(self):
+        ''' calculate the abstractness metric using A = Na / Nc:
+        0 -> no abstract classes, 1 -> only abstract classes.
+        info: since it might be possible that some files do not contain any class definition at all
+        each division checks for a division through zero '''
+        n_a = self._interface_class_matrix.loc['N_a', :]
+        n_c = self._interface_class_matrix.loc['N_c', :]
+
+        # copy to get names in actual order, rename resulting array and change it's type accordingly
+        a = n_a
+        a = a.rename(index='Abstractness-Metric')
+        a = a.astype(float)
+
+        # compute abstractness metric for each row
+        for index in range(len(n_a)):
+            # prevent division through 0
+            if n_c[index] == 0:
+                a[index] = 0
+            else:
+                a[index] = n_a[index] / n_c[index]
+
+        return a
+
+    def compute_abstractness(self):
+        ''' encapsulate all methods necessary to compute the abstractness values for each file:
+        1) get all code file which are considered for calculating the metric
+        2) extract all interfaces/abstract classed from those files
+        3) calculate the abstractness metric '''
+        allowed_file_extensions = []
+        try:
+            allowed_file_extensions = ProgrammingLanguageConfig.get_file_extensions_am()
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
+            warnings.warn(ex.args)
+
+        self._list_of_files = FileUtility.get_all_code_files(self._dir_path, allowed_file_extensions)
+        self._search_files_for_interfaces()
+        abstractness_metric = self._calculate_abstractness_for_each_file()
+
+        return abstractness_metric

--- a/tests/modules_under_test/metrics/distance_ia.py
+++ b/tests/modules_under_test/metrics/distance_ia.py
@@ -27,7 +27,7 @@ class DistanceIA:
         ''' show a diagram picturing the distance in each components, where
         - y-axis denotes the distance
         - x-axis denotes the different files/components '''
-        self._instability_metric, self._abstractness_metric =
+        self._instability_metric, self._abstractness_metric = \
             DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
         self._calculate_distance()
 

--- a/tests/modules_under_test/metrics/distance_ia.py
+++ b/tests/modules_under_test/metrics/distance_ia.py
@@ -1,0 +1,49 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import sys
+sys.path.append('tests/modules_under_test/')
+from utils import DataSeriesUtility, FileUtility
+
+
+class DistanceIA:
+    def __init__(self, dir_path):
+        self._dir_path = dir_path
+        self._instability_metric = None
+        self._abstractness_metric = None
+        self._distance = None
+
+    def _calculate_distance(self):
+        ''' calculates the distance between Abstractness and Instability of each file/component using
+        D = |A+I-1|, with D being in range [0;1] with a
+        ...D of 0 indicating that the corresponding file/component lies on the Main Sequence
+        ...D of 1 indicating that the corresponding file/component lies far away from the Main Sequence '''
+        self._distance = abs(self._abstractness_metric + self._instability_metric - 1)
+
+        # provide a name to data series required for saving it to a file
+        self._distance = self._distance.rename('Distance_IA')
+
+    def plot_distance(self):
+        ''' show a diagram picturing the distance in each components, where
+        - y-axis denotes the distance
+        - x-axis denotes the different files/components '''
+        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+        self._calculate_distance()
+
+        ind = np.arange(self._distance.size)
+
+        # x = files/components, y = distance
+        plt.plot(ind, self._distance, marker='x', linestyle='None')
+        plt.xticks(ind, self._instability_metric.index, rotation=45, ha='right')
+        plt.ylabel('[D]istance', fontsize=18)
+
+        plt.show()
+
+    def save_metric(self, dir_path=''):
+        ''' save distance metric to directory. If provided use user-defined directory '''
+        # if not already computed get distance
+        if self._distance is None:
+            self._calculate_distance()
+
+        # save it
+        FileUtility.save_metric_to_file(self._distance, dir_path)

--- a/tests/modules_under_test/metrics/distance_ia.py
+++ b/tests/modules_under_test/metrics/distance_ia.py
@@ -27,7 +27,8 @@ class DistanceIA:
         ''' show a diagram picturing the distance in each components, where
         - y-axis denotes the distance
         - x-axis denotes the different files/components '''
-        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric =
+            DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
         self._calculate_distance()
 
         ind = np.arange(self._distance.size)

--- a/tests/modules_under_test/metrics/instability_metric.py
+++ b/tests/modules_under_test/metrics/instability_metric.py
@@ -1,0 +1,133 @@
+import numpy as np
+import pandas as pd
+import warnings
+
+import sys
+sys.path.append('tests/modules_under_test/')
+from utils import FileUtility, ProgrammingLanguageConfig
+
+
+class InstabilityMetric:
+    def __init__(self, dir_path):
+        self._dir_path = dir_path
+        self._list_of_user_files = []
+        self._include_matrix = pd.DataFrame()
+
+    def _get_includes_of_file(self, file_path):
+        ''' return the files included with #include "..." and #include <...> in provided file
+        in two separated arrays, one for user-includes and one for stl-includes '''
+        user_include_list = []
+        stl_include_list = []
+
+        try:
+            with open(file_path, 'r') as file:
+                for line in file:
+                    if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
+                        # ignore ending " to get the pure filename
+                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
+                        user_include_list.append(include_filename)
+                    elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
+                        # ignore ending > to get the pure filename
+                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
+                        stl_include_list.append(include_filename)
+
+        except FileNotFoundError as ex:
+            warnings.warn('{} ...returning default values'.format(ex))
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
+            warnings.warn(ex.args)
+
+        return user_include_list, stl_include_list
+
+    def _create_user_include_matrix(self):
+        ''' create a 2D matrix with dim = m x n, where m is the number of user-included files '''
+        m = len(self._list_of_user_files)
+        null_matrix = np.zeros((m, m), dtype=int)
+        names = [FileUtility.extract_filename(filepath) for filepath in self._list_of_user_files]
+        self._include_matrix = pd.DataFrame(null_matrix, index=names, columns=names)
+
+    def _fill_include_matrix(self):
+        ''' fill matrix by setting matrix[x,y] to 1 if x includes y for all user-included files, which
+        are indicated by #include "...". Additonally, stl-included files are also handled '''
+        # check includes
+        for filepath in self._list_of_user_files:
+            # get filename which includes the following files
+            including_file = FileUtility.extract_filename(filepath)
+
+            # get list of user-includes
+            user_includes, stl_includes = self._get_includes_of_file(filepath)
+
+            # #include "..." usage, fill 1 if needed (row=including_file, column=user_included_file)
+            for user_included_file in user_includes:
+                self._include_matrix.at[including_file, user_included_file] = 1
+
+            # #include <...> usage, fill 1 if needed (row=including_file, column=stl_included_file)
+            for stl_included_file in stl_includes:
+                self._include_matrix.at[including_file, stl_included_file] = 1
+
+    def _add_stl_includes(self):
+        ''' In order to be able to handle included stl-files, each time an including_file includes stl-files
+        (indicated by #include <...>), they are added to a member-list '''
+        self._list_of_stl_libs = []
+
+        # check includes
+        for filepath in self._list_of_user_files:
+            # get list of stl-includes
+            _, stl_includes = self._get_includes_of_file(filepath)
+
+            # #include <...> usage, add stl-files to global list
+            for stl_included_file in stl_includes:
+                self._list_of_stl_libs.append(stl_included_file)
+
+        # remove duplicates of global stl-files list
+        self._list_of_stl_libs = list(set(self._list_of_stl_libs))
+
+        for stl_included_file in self._list_of_stl_libs:
+            self._include_matrix.loc[:, stl_included_file] = pd.Series(np.zeros(len(self._include_matrix.index)), dtype=int)
+
+    def _get_all_fan_in(self):
+        ''' uses provided data frame to evaluate the fan-in's of each file (:= #1's in row) '''
+        return np.sum(self._include_matrix, axis=1)
+
+    def _get_all_fan_out(self):
+        ''' uses provided data frame to evaluate the fan-out's of each file (:= #1's in column) '''
+        return np.sum(self._include_matrix, axis=0)
+
+    def _calculate_instability_for_each_file(self):
+        ''' calculate the instability metric using I = fan_out / (fan_in + fan_out):
+        1 -> unstable, 0 -> stable.
+        info: fan_in might contain less values than fan_out due to the included stl-files, and hence
+        each row has its counterpart in the columns for shape m x m, if index(column) > m the symmetry
+        broken '''
+        fan_in = self._get_all_fan_in()
+        fan_out = self._get_all_fan_out()
+
+        # copy to get names in actual order
+        i = fan_in
+        i = i.rename(index='Instability-Metric')
+        i = i.astype(float)
+
+        # compute instability metric for each row
+        for index in range(len(fan_in)):
+            # prevent division through 0
+            if fan_out[index] == 0 and fan_in[index] == 0:
+                i[index] = 0
+            else:
+                i[index] = fan_out[index] / (fan_in[index] + fan_out[index])
+
+        return i
+
+    def compute_instability(self):
+        ''' encapsulate all methods necessary to compute the instability values for each component '''
+        allowed_file_extensions = []
+        try:
+            allowed_file_extensions = ProgrammingLanguageConfig.get_file_extensions_im()
+        except ProgrammingLanguageConfig.LanguageOptionError as ex:
+            warnings.warn(ex.args)
+
+        self._list_of_user_files = FileUtility.get_all_code_files(self._dir_path, allowed_file_extensions)
+        self._create_user_include_matrix()
+        self._add_stl_includes()
+        self._fill_include_matrix()
+        instability_metric = self._calculate_instability_for_each_file()
+
+        return instability_metric

--- a/tests/modules_under_test/metrics/instability_metric.py
+++ b/tests/modules_under_test/metrics/instability_metric.py
@@ -24,11 +24,13 @@ class InstabilityMetric:
                 for line in file:
                     if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
                         # ignore ending " to get the pure filename
-                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
+                        include_filename =
+                            line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
                         user_include_list.append(include_filename)
                     elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
                         # ignore ending > to get the pure filename
-                        include_filename = line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
+                        include_filename =
+                            line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
                         stl_include_list.append(include_filename)
 
         except FileNotFoundError as ex:

--- a/tests/modules_under_test/metrics/instability_metric.py
+++ b/tests/modules_under_test/metrics/instability_metric.py
@@ -24,12 +24,12 @@ class InstabilityMetric:
                 for line in file:
                     if line.startswith(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):
                         # ignore ending " to get the pure filename
-                        include_filename =
+                        include_filename = \
                             line[len(ProgrammingLanguageConfig.get_prefix_user_include_identifier()):].strip()[:-1]
                         user_include_list.append(include_filename)
                     elif line.startswith(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):
                         # ignore ending > to get the pure filename
-                        include_filename =
+                        include_filename = \
                             line[len(ProgrammingLanguageConfig.get_prefix_standard_include_identifier()):].strip()[:-1]
                         stl_include_list.append(include_filename)
 

--- a/tests/modules_under_test/metrics/main_sequence.py
+++ b/tests/modules_under_test/metrics/main_sequence.py
@@ -1,0 +1,141 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import warnings
+
+import sys
+sys.path.append('tests/modules_under_test/')
+from utils import DataSeriesUtility, FileUtility
+
+
+class MainSequence:
+    def __init__(self, dir_path):
+        self._dir_path = dir_path
+        self._annotation_points = []
+        self._last_hov_anno_index = -1
+        self._instability_metric = None
+        self._abstractness_metric = None
+
+    def _annotate_point(self, event, sc):  # noqa: C901
+        ''' displays a text, if a user hovers over a point with the mouse '''
+        fig = plt.gcf()
+        visibility_changed = False
+
+        if event.inaxes == plt.gca():
+            anno_visible, ind = sc.contains(event)
+            ind_array = ind['ind']
+
+            # check if not hovering over a point (empty index list)
+            if ind_array.size == 0:
+                for annotation in self._annotation_points:
+                    # make sure every annotation is invisible
+                    if annotation.get_visible():
+                        annotation.set_visible(False)
+                        visibility_changed = True
+
+            # only one annotation available
+            elif ind_array.size == 1:
+                if not self._annotation_points[ind_array[0]].get_visible():
+                    self._annotation_points[ind_array[0]].set_visible(True)
+                    visibility_changed = True
+
+            # more than one annotation available (display only one)
+            else:
+                # again hovered over the same summary of points
+                if self._last_hov_anno_index in ind_array:
+                    # do not change annotation if mouse still is on point
+                    if self._annotation_points[self._last_hov_anno_index].get_visible():
+                        return
+
+                    # get array index and increment it
+                    arr_ind, = np.where(ind_array == self._last_hov_anno_index)
+                    next_arr_ind = arr_ind[0] + 1
+
+                    # start from beginning if end of array indices is reached
+                    if next_arr_ind == ind_array.size:
+                        next_arr_ind = 0
+
+                    # map array index to annotation index
+                    anno_ind = ind_array[next_arr_ind]
+
+                    # set respective annotation visible
+                    self._annotation_points[anno_ind].set_visible(True)
+                    visibility_changed = True
+                    self._last_hov_anno_index = anno_ind
+
+                # hovered over another summary of points
+                else:
+                    self._annotation_points[ind_array[0]].set_visible(True)
+                    visibility_changed = True
+                    self._last_hov_anno_index = ind_array[0]
+
+        if visibility_changed:
+            fig.canvas.draw_idle()
+
+    def _layout_ax(self):
+        ''' creates and returns the basic layout of the diagram displayed '''
+        ax = plt.gca()
+
+        # x/y range from 0 to 1
+        ax.set_xlim((0, 1))
+        ax.set_ylim((0, 1))
+
+        # Main Sequence
+        ax.plot([0, 1], [1, 0], marker='x', color='red')
+
+        # zone of pain
+        ax.add_artist(plt.Circle((0, 0), .5, alpha=.3, color='r'))
+        ax.annotate("Zone of Pain", xy=(.1, .2), fontsize=10)
+
+        # zone of uselessness
+        ax.add_artist(plt.Circle((1, 1), .5, alpha=.3, color='r'))
+        ax.annotate("Zone of Uselessness", xy=(.65, .8), fontsize=10)
+
+        # label x and y
+        ax.set_xlabel('[I]nstability', fontsize=18)
+        ax.set_ylabel('[A]bstractness', fontsize=18)
+
+        return ax
+
+    def _define_motion_annotation_callback(self, sc):
+        ''' fill displayed diagram with a mouse-event to show annotations within it '''
+        fig = plt.gcf()
+        fig.canvas.set_window_title('Main Sequence')
+
+        # check for empty name map
+        if self._annotation_points == []:
+            warnings.warn('"self._names_map" is empty...returning directly, no motion_notifiy_event connected')
+            return
+
+        # callback executed at each mouse motion event
+        fig.canvas.mpl_connect("motion_notify_event", lambda event: self._annotate_point(event, sc))
+
+    def plot_metrics(self):
+        ''' show a diagram picturing the Main Sequence, where
+        - y-axis denotes the Abstractness
+        - x-axis denotes the Instability '''
+        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+
+        # create basic layout format
+        ax = self._layout_ax()
+
+        # create a list which contains all annotations
+        self._annotation_points = [ax.annotate(n, (x, y), visible=False) for n, x, y in
+                                   zip(self._instability_metric.index, self._instability_metric, self._abstractness_metric)]
+
+        # x = instability, y = abstractness
+        sc = ax.scatter(self._instability_metric, self._abstractness_metric)
+
+        # use a motion-event to display annotations
+        self._define_motion_annotation_callback(sc)
+
+        plt.show()
+
+    def save_metrics(self, dir_path=''):
+        ''' save both metrics to directory. If provided use user-defined directory '''
+        # if not already computed get metrics
+        if self._instability_metric is None or self._abstractness_metric is None:
+            self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+
+        # save them
+        FileUtility.save_metric_to_file(self._instability_metric, dir_path)
+        FileUtility.save_metric_to_file(self._abstractness_metric, dir_path)

--- a/tests/modules_under_test/metrics/main_sequence.py
+++ b/tests/modules_under_test/metrics/main_sequence.py
@@ -113,7 +113,7 @@ class MainSequence:
         ''' show a diagram picturing the Main Sequence, where
         - y-axis denotes the Abstractness
         - x-axis denotes the Instability '''
-        self._instability_metric, self._abstractness_metric =
+        self._instability_metric, self._abstractness_metric = \
             DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # create basic layout format

--- a/tests/modules_under_test/metrics/main_sequence.py
+++ b/tests/modules_under_test/metrics/main_sequence.py
@@ -113,7 +113,8 @@ class MainSequence:
         ''' show a diagram picturing the Main Sequence, where
         - y-axis denotes the Abstractness
         - x-axis denotes the Instability '''
-        self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+        self._instability_metric, self._abstractness_metric =
+            DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # create basic layout format
         ax = self._layout_ax()
@@ -134,7 +135,8 @@ class MainSequence:
         ''' save both metrics to directory. If provided use user-defined directory '''
         # if not already computed get metrics
         if self._instability_metric is None or self._abstractness_metric is None:
-            self._instability_metric, self._abstractness_metric = DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
+            self._instability_metric, self._abstractness_metric =
+                DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # save them
         FileUtility.save_metric_to_file(self._instability_metric, dir_path)

--- a/tests/modules_under_test/metrics/main_sequence.py
+++ b/tests/modules_under_test/metrics/main_sequence.py
@@ -135,7 +135,7 @@ class MainSequence:
         ''' save both metrics to directory. If provided use user-defined directory '''
         # if not already computed get metrics
         if self._instability_metric is None or self._abstractness_metric is None:
-            self._instability_metric, self._abstractness_metric =
+            self._instability_metric, self._abstractness_metric = \
                 DataSeriesUtility.get_instability_and_abstractness_metric(self._dir_path)
 
         # save them

--- a/tests/modules_under_test/utils/DataSeriesUtility.py
+++ b/tests/modules_under_test/utils/DataSeriesUtility.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+import sys
+sys.path.append('tests/modules_under_test/metrics/')
+from instability_metric import InstabilityMetric
+from abstractness_metric import AbstractnessMetric
+
+
+# default value used to pad data-sequences to required size
+DEFAULT_PADDING_VALUE = 0
+
+
+def get_instability_and_abstractness_metric(dir_path):
+    ''' return instability and abstractness metric. If one array is of lower size than the other,
+    it has to be extended with the default values to be able to plot it '''
+    instabilityMetric = InstabilityMetric(dir_path)
+    instability_metric = instabilityMetric.compute_instability()
+
+    abstractnessMetric = AbstractnessMetric(dir_path)
+    abstractness_metric = abstractnessMetric.compute_abstractness()
+
+    # for each instability-value an abstractness-value needs to exist
+    if len(instability_metric) > len(abstractness_metric):
+        abstractness_metric = pad_data_series_with_default_values(instability_metric, abstractness_metric)
+    # for each abstractness-value an instability-value needs to exist
+    elif len(abstractness_metric) > len(instability_metric):
+        instability_metric = pad_data_series_with_default_values(abstractness_metric, instability_metric)
+
+    # order elements of array the same
+    abstractness_metric = reorder_data_series_elements(instability_metric, abstractness_metric)
+
+    # return both metrics
+    return instability_metric, abstractness_metric
+
+
+def pad_data_series_with_default_values(data_series, data_series_to_pad):
+    ''' pad data_series_to_pad with default values to be the same size as data_series
+    and contain the same index-names, too. Return the padded data-series '''
+    if not isinstance(data_series, type(pd.Series(dtype=float))) or \
+       not isinstance(data_series_to_pad, type(pd.Series(dtype=float))):
+        return pd.Series(dtype=float)
+
+    padded_data_series = data_series_to_pad
+    for index_name in data_series.index:
+        if index_name not in data_series_to_pad:
+            padded_data_series[index_name] = DEFAULT_PADDING_VALUE
+
+    return padded_data_series
+
+
+def reorder_data_series_elements(data_series, data_series_to_reorder):
+    ''' order elements in data_series_to_reorder the same way as they are in data_series '''
+    if not isinstance(data_series, type(pd.Series(dtype=float))) or \
+       not isinstance(data_series_to_reorder, type(pd.Series(dtype=float))):
+        return pd.Series(dtype=float)
+
+    ordered_data_series = pd.Series(name=data_series_to_reorder.name, dtype=float)
+    for index_name in data_series.index:
+        ordered_data_series[index_name] = data_series_to_reorder[index_name]
+
+    return ordered_data_series

--- a/tests/modules_under_test/utils/FileUtility.py
+++ b/tests/modules_under_test/utils/FileUtility.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+import glob
+from pathlib import Path
+import warnings
+
+# glob extends paths with \
+PATH_DELIMITER = '\\'
+
+# default directory for saved metric
+DEFAULT_DIRECTORY = 'saved_metrics'
+
+
+def get_all_code_files(directory_path, allowed_file_extensions):
+    ''' return a list containing all files with the provided file-extension(s) found in the given directory '''
+    code_files = []
+
+    # check that 2nd parameter is of type list, if not return empty list
+    if not isinstance(allowed_file_extensions, list):
+        warnings.warn('"allowed_file_extensions" is not of required type list. Returning empty list..')
+        return code_files
+
+    for extension in allowed_file_extensions:
+        directory_content = [file for file in glob.glob(directory_path + "**/*." + extension, recursive=True)]
+
+        # add files of given extension to list
+        code_files += [file for file in directory_content]
+
+    return code_files
+
+
+def extract_filename(filepath):
+    ''' return solely the filename including the extension '''
+    # get last part of file_path
+    filename = filepath.split(PATH_DELIMITER)[-1]
+
+    return filename
+
+
+def save_metric_to_file(metric, directory_path=''):
+    ''' save given metric to given directory-path. Use (and create) default directory if it does not exist '''
+    # use default directory if provided path does not exist
+    if not Path(directory_path).is_dir() or directory_path == '':
+        directory_path = Path.joinpath(Path.cwd().absolute(), DEFAULT_DIRECTORY)
+
+        # create default directory if not already existing
+        if not Path(directory_path).is_dir():
+            Path(directory_path).mkdir(parents=True, exist_ok=True)
+    else:
+        # create Path object otw.
+        directory_path = Path(directory_path)
+
+    filename = '{}_{}.csv'.format(metric.name.lower(), datetime.now().strftime('%Y-%m-%d_%H-%M-%S'))
+    filepath = Path.joinpath(directory_path, filename)
+    metric.to_csv(filepath)

--- a/tests/modules_under_test/utils/ProgrammingLanguageConfig.py
+++ b/tests/modules_under_test/utils/ProgrammingLanguageConfig.py
@@ -1,0 +1,72 @@
+from utils import ProgrammingLanguageConstants
+
+PROGRAMMING_LANGUAGE = ''
+
+
+class LanguageOptionError(RuntimeError):
+    ''' user-defined exception used if getter is not applicable to certain languages'''
+    def __init__(self, arg):
+        self.args = arg
+
+    def __str__(self):
+        error_string = ''
+        for chr in self.args:
+            error_string += chr
+
+        return "LanguageOptionError: {}".format(error_string)
+
+
+def get_file_extensions_im():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_ALLOWED_FILE_EXTENSIONS_IM
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_file_extensions_am():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_ALLOWED_FILE_EXTENSIONS_AM
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_class_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_CLASS_IDENTIFIER
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_interface_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        raise LanguageOptionError('C++ does not have an interface identifier')
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_abstract_method_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_ABSTRACT_METHOD_IDENTIFIER
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_namespace_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_NAMESPACE_IDENTIFIER
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_prefix_user_include_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_PREFIX_USER_INCLUDE
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))
+
+
+def get_prefix_standard_include_identifier():
+    if PROGRAMMING_LANGUAGE == 'c++':
+        return ProgrammingLanguageConstants.CPP_PREFIX_STD_INCLUDE
+    else:
+        raise LanguageOptionError("Programming language '{}' is currently not supported!".format(PROGRAMMING_LANGUAGE))

--- a/tests/modules_under_test/utils/ProgrammingLanguageConstants.py
+++ b/tests/modules_under_test/utils/ProgrammingLanguageConstants.py
@@ -1,0 +1,34 @@
+#################################
+# abstractness metric constants #
+#################################
+
+#######
+# C++ #
+#######
+CPP_ALLOWED_FILE_EXTENSIONS_AM = ['hpp', 'h']
+
+# [\w()]* handles the __ declspec(dllexport)-part of class definition:
+# e.g. class __declspec(dllexport) ModbusTcpClient
+CPP_CLASS_IDENTIFIER = '\s*(class|struct)\s*[\w()]*\s*\w+\s*'  # noqa: W605
+
+# abstract methods in C++ are typically denoted by setting a virtual method equal to 0:
+# e.g. virtual void anAbstractMethod() = 0;
+# it starts with (virtual) and ends with (= 0;)
+CPP_ABSTRACT_METHOD_IDENTIFIER = '^(\s*virtual)\s+\w+\s*\w*\((.|\s)*\)\s*\w*\s*(=\s*0\s*;)$'  # noqa: W605
+
+# namespaces are indicated by namespace namespaceX
+CPP_NAMESPACE_IDENTIFIER = '^(\s*namespace)\s*\w*\s*'  # noqa: W605
+
+
+#################################
+# instability metric constants  #
+#################################
+
+#######
+# C++ #
+#######
+CPP_ALLOWED_FILE_EXTENSIONS_IM = ['cpp', 'hpp', 'c', 'h']
+
+# includes-libraries (user/std) in C++ files
+CPP_PREFIX_STD_INCLUDE = '#include <'
+CPP_PREFIX_USER_INCLUDE = '#include "'

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -12,6 +12,11 @@ import Test_InstabilityMetric as t_im
 import Test_DistanceIA as t_dia
 import Test_MainSequence as t_ms
 
+# append path to include all modules to test
+sys.path.append('tests/modules_under_test/')
+from utils import ProgrammingLanguageConfig as plc
+plc.PROGRAMMING_LANGUAGE = 'c++'
+
 # create TestSuite with all testcases
 suite = unittest.TestSuite()
 

--- a/tests/test_metrics/Test_AbstractnessMetric.py
+++ b/tests/test_metrics/Test_AbstractnessMetric.py
@@ -2,23 +2,17 @@ import os
 import pandas as pd
 import unittest
 from unittest.mock import patch
-import sys
 import warnings
 
-sys.path.append('scm_modules/utils/')
-import FileUtility as fut
-import ProgrammingLanguageConfig as plc
+import utils.FileUtility as fut
+import utils.ProgrammingLanguageConfig as plc
 
-sys.path.append('scm_modules/metrics/')
-from abstractness_metric import AbstractnessMetric
+from metrics.abstractness_metric import AbstractnessMetric
 
 # constants
 TEST_CODE_FILES = 'tests/files/abstractness_metric_test_files/'
 ABSTRACT_CLASS_FILE = TEST_CODE_FILES + 'abstract_class.h'
 NON_ABSTRACT_CLASS_FILE = TEST_CODE_FILES + 'non_abstract_class.h'
-
-# set programming language to c++
-plc.PROGRAMMING_LANGUAGE = 'c++'
 
 
 def createUUT(dir_path=''):
@@ -75,7 +69,7 @@ class TestAbstractnessMetricGetNumberOfInterfacesAndClassesOfFile(unittest.TestC
 
 
 class TestAbstractnessMetricSearchFilesForInterfaces(unittest.TestCase):
-    @patch('abstractness_metric.AbstractnessMetric._get_number_of_interfaces_and_classes_of_file')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._get_number_of_interfaces_and_classes_of_file')
     def testCorrectNumberOfFunctionCalls(self, mocked_a_get_func):
         '''
         Test that mocked function is called as often as files are present in the given directory
@@ -95,8 +89,8 @@ class TestAbstractnessMetricSearchFilesForInterfaces(unittest.TestCase):
             expected_nb_method_calls = len(os.listdir(TEST_CODE_FILES))
             self.assertEqual(mocked_a_get_func.call_count, expected_nb_method_calls)
 
-    @patch('abstractness_metric.AbstractnessMetric._get_number_of_interfaces_and_classes_of_file')
-    @patch('FileUtility.extract_filename')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._get_number_of_interfaces_and_classes_of_file')
+    @patch('utils.FileUtility.extract_filename')
     def testCorrectSettingOfCellsInMatrix(self, mocked_fut_func, mocked_a_get_func):
         '''
         Test that a correct cell is set in the member-matrix
@@ -144,9 +138,9 @@ class TestAbstractnessMetricCalculateAbstractnessForEachFile(unittest.TestCase):
 
 
 class TestAbstractnessMetricComputeAbstractness(unittest.TestCase):
-    @patch('FileUtility.get_all_code_files')
-    @patch('abstractness_metric.AbstractnessMetric._search_files_for_interfaces')
-    @patch('abstractness_metric.AbstractnessMetric._calculate_abstractness_for_each_file')
+    @patch('utils.FileUtility.get_all_code_files')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._search_files_for_interfaces')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._calculate_abstractness_for_each_file')
     def testCorrectFunctionCallsWithEmptyFilePath(self, mocked_a_calc_func, mocked_a_search_func, mocked_fut_get_func):
         '''
         Test that the correct functions are invoked when an empty filepath was provided
@@ -165,9 +159,9 @@ class TestAbstractnessMetricComputeAbstractness(unittest.TestCase):
         mocked_a_search_func.assert_called_once()
         mocked_a_calc_func.assert_called_once()
 
-    @patch('FileUtility.get_all_code_files')
-    @patch('abstractness_metric.AbstractnessMetric._search_files_for_interfaces')
-    @patch('abstractness_metric.AbstractnessMetric._calculate_abstractness_for_each_file')
+    @patch('utils.FileUtility.get_all_code_files')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._search_files_for_interfaces')
+    @patch('metrics.abstractness_metric.AbstractnessMetric._calculate_abstractness_for_each_file')
     def testCorrectFunctionCallsWithNonEmptyFilePath(self, mocked_a_calc_func, mocked_a_search_func, mocked_fut_get_func):
         '''
         Test that the correct functions are invoked when a non-empty filepath was provided

--- a/tests/test_metrics/Test_DistanceIA.py
+++ b/tests/test_metrics/Test_DistanceIA.py
@@ -3,15 +3,11 @@ import numpy as np
 import pandas as pd
 import unittest
 from unittest.mock import patch
-import sys
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import DataSeriesUtility as dsu
-import FileUtility as fut
+import utils.DataSeriesUtility as dsu
+import utils.FileUtility as fut
 
-sys.path.append('scm_modules/metrics/')
-from distance_ia import DistanceIA
+from metrics.distance_ia import DistanceIA
 
 
 def createUUT():
@@ -44,8 +40,8 @@ class TestDistanceIAPlotDistance(unittest.TestCase):
     @patch('matplotlib.pyplot.xticks')
     @patch('matplotlib.pyplot.plot')
     @patch('matplotlib.pyplot.show')
-    @patch('DataSeriesUtility.get_instability_and_abstractness_metric')
-    @patch('distance_ia.DistanceIA._calculate_distance')
+    @patch('utils.DataSeriesUtility.get_instability_and_abstractness_metric')
+    @patch('metrics.distance_ia.DistanceIA._calculate_distance')
     def testCorrectFunctionCalls(self, mocked_d_func, mocked_dsu_func, mocked_show_func, mocked_plot_func,
                                  mocked_xticks_func, mocked_ylabel_func):
         '''
@@ -83,8 +79,8 @@ class TestDistanceIAPlotDistance(unittest.TestCase):
     @patch('matplotlib.pyplot.xticks')
     @patch('matplotlib.pyplot.plot')
     @patch('matplotlib.pyplot.show')
-    @patch('DataSeriesUtility.get_instability_and_abstractness_metric')
-    @patch('distance_ia.DistanceIA._calculate_distance')
+    @patch('utils.DataSeriesUtility.get_instability_and_abstractness_metric')
+    @patch('metrics.distance_ia.DistanceIA._calculate_distance')
     def testCorrectFunctionCallArguments(self, mocked_d_func, mocked_dsu_func, mocked_show_func,
                                          mocked_plot_func, mocked_xticks_func, mocked_ylabel_func):
         '''
@@ -133,7 +129,7 @@ class TestDistanceIAPlotDistance(unittest.TestCase):
 
 
 class TestDistanceIASaveMetrics(unittest.TestCase):
-    @patch('FileUtility.save_metric_to_file')
+    @patch('utils.FileUtility.save_metric_to_file')
     def testCorrectFunctionCallsIfMetricIsExisting(self, mocked_fut_save_func):
         '''
         Test that correct functions are invoked if metric is already existing
@@ -153,8 +149,8 @@ class TestDistanceIASaveMetrics(unittest.TestCase):
             # assert call
             mocked_fut_save_func.assert_called_once()
 
-    @patch('FileUtility.save_metric_to_file')
-    @patch('distance_ia.DistanceIA._calculate_distance')
+    @patch('utils.FileUtility.save_metric_to_file')
+    @patch('metrics.distance_ia.DistanceIA._calculate_distance')
     def testCorrectFunctionCallsIfMetricNotExisting(self, mocked_d_calc_func, mocked_fut_save_func):
         '''
         Test that correct functions are invoked if metrics is not existing

--- a/tests/test_metrics/Test_InstabilityMetric.py
+++ b/tests/test_metrics/Test_InstabilityMetric.py
@@ -3,14 +3,11 @@ import os
 import pandas as pd
 import unittest
 from unittest.mock import patch
-import sys
 import warnings
 
-sys.path.append('scm_modules/utils/')
-import FileUtility as fut
+import utils.FileUtility as fut
 
-sys.path.append('scm_modules/metrics/')
-from instability_metric import InstabilityMetric
+from metrics.instability_metric import InstabilityMetric
 
 # constants
 TEST_CODE_FILES = 'tests/files/instability_metric_test_files/'
@@ -83,7 +80,7 @@ class TestInstabilityMetricGetIncludesOfFile(unittest.TestCase):
 
 
 class TestInstabilityMetricCreateUserIncludeMatrix(unittest.TestCase):
-    @patch('FileUtility.extract_filename')
+    @patch('utils.FileUtility.extract_filename')
     def testCorrectSizeOfMatrix(self, mocked_fut_func):
         '''
         Test that the size of the returned matrix is correct
@@ -102,7 +99,7 @@ class TestInstabilityMetricCreateUserIncludeMatrix(unittest.TestCase):
             # assert correct size of matrix
             self.assertEqual(instability_metric._include_matrix.shape, instability_metric._include_matrix.shape)
 
-    @patch('FileUtility.extract_filename')
+    @patch('utils.FileUtility.extract_filename')
     def testCorrectIndexAndColumnLabelsOfMatrix(self, mocked_fut_func):
         '''
         Test that the rows and columns are labeled correctly depending on the filenames
@@ -127,8 +124,8 @@ class TestInstabilityMetricCreateUserIncludeMatrix(unittest.TestCase):
 
 
 class TestInstabilityMetricFillIncludeMatrix(unittest.TestCase):
-    @patch('FileUtility.extract_filename')
-    @patch('instability_metric.InstabilityMetric._get_includes_of_file')
+    @patch('utils.FileUtility.extract_filename')
+    @patch('metrics.instability_metric.InstabilityMetric._get_includes_of_file')
     def testCheckMatrixIfNoIncludes(self, mocked_i_func, mocked_fut_func):
         '''
         Test that the member-matrix remains unchanged (only 0s), if no include files are found
@@ -158,8 +155,8 @@ class TestInstabilityMetricFillIncludeMatrix(unittest.TestCase):
                 mocked_i_func.assert_called()
                 self.assertTrue(instability_metric._include_matrix.equals(expected_include_matrix))
 
-    @patch('FileUtility.extract_filename')
-    @patch('instability_metric.InstabilityMetric._get_includes_of_file')
+    @patch('utils.FileUtility.extract_filename')
+    @patch('metrics.instability_metric.InstabilityMetric._get_includes_of_file')
     def testCheckMatrixIfIncludes(self, mocked_i_func, mocked_fut_func):
         '''
         Test that the correct member-matrix is returned, if include files are found
@@ -205,7 +202,7 @@ class TestInstabilityMetricFillIncludeMatrix(unittest.TestCase):
 
 
 class TestInstabilityMetricAddStlIncludes(unittest.TestCase):
-    @patch('instability_metric.InstabilityMetric._get_includes_of_file')
+    @patch('metrics.instability_metric.InstabilityMetric._get_includes_of_file')
     def testEmtpyStlIncludes(self, mocked_i_func):
         '''
         Test that no column is added to existing matrix if no STL includes are found
@@ -231,7 +228,7 @@ class TestInstabilityMetricAddStlIncludes(unittest.TestCase):
                 self.assertTrue(instability_metric._include_matrix.equals(expected_include_matrix))
                 self.assertEqual(instability_metric._include_matrix.shape, expected_include_matrix.shape)
 
-    @patch('instability_metric.InstabilityMetric._get_includes_of_file')
+    @patch('metrics.instability_metric.InstabilityMetric._get_includes_of_file')
     def testNonEmtpyStlIncludes(self, mocked_i_func):
         '''
         Test that columns are added to existing matrix if STL includes are found
@@ -256,7 +253,7 @@ class TestInstabilityMetricAddStlIncludes(unittest.TestCase):
                 mocked_i_func.assert_called()
                 self.assertEqual(instability_metric._include_matrix.shape, expected_include_matrix_shape)
 
-    @patch('instability_metric.InstabilityMetric._get_includes_of_file')
+    @patch('metrics.instability_metric.InstabilityMetric._get_includes_of_file')
     def testNoDuplicatedStlIncludes(self, mocked_i_func):
         '''
         Test that duplicated stl-includes are added as a single column
@@ -315,8 +312,8 @@ class TestInstabilityMetricGetAllFanOut(unittest.TestCase):
 
 
 class TestInstabilityMetricCalculateInstabilityForEachFile(unittest.TestCase):
-    @patch('instability_metric.InstabilityMetric._get_all_fan_out')
-    @patch('instability_metric.InstabilityMetric._get_all_fan_in')
+    @patch('metrics.instability_metric.InstabilityMetric._get_all_fan_out')
+    @patch('metrics.instability_metric.InstabilityMetric._get_all_fan_in')
     def testCorrectCalculation(self, mocked_i_func_in, mocked_i_func_out):
         '''
         Test that a the instability metric is computed correctly
@@ -356,11 +353,11 @@ class TestInstabilityMetricCalculateInstabilityForEachFile(unittest.TestCase):
 
 
 class TestInstabilityMetricComputeInstability(unittest.TestCase):
-    @patch('FileUtility.get_all_code_files')
-    @patch('instability_metric.InstabilityMetric._create_user_include_matrix')
-    @patch('instability_metric.InstabilityMetric._add_stl_includes')
-    @patch('instability_metric.InstabilityMetric._fill_include_matrix')
-    @patch('instability_metric.InstabilityMetric._calculate_instability_for_each_file')
+    @patch('utils.FileUtility.get_all_code_files')
+    @patch('metrics.instability_metric.InstabilityMetric._create_user_include_matrix')
+    @patch('metrics.instability_metric.InstabilityMetric._add_stl_includes')
+    @patch('metrics.instability_metric.InstabilityMetric._fill_include_matrix')
+    @patch('metrics.instability_metric.InstabilityMetric._calculate_instability_for_each_file')
     def testCorrectFunctionCallsWithEmptyFilePath(self, mocked_i_calc_func, mocked_i_fill_func, mocked_i_add_func,
                                                   mocked_i_create_func, mocked_fut_get_func):
         '''
@@ -384,11 +381,11 @@ class TestInstabilityMetricComputeInstability(unittest.TestCase):
         mocked_i_fill_func.assert_called_once()
         mocked_i_calc_func.assert_called_once()
 
-    @patch('FileUtility.get_all_code_files')
-    @patch('instability_metric.InstabilityMetric._create_user_include_matrix')
-    @patch('instability_metric.InstabilityMetric._add_stl_includes')
-    @patch('instability_metric.InstabilityMetric._fill_include_matrix')
-    @patch('instability_metric.InstabilityMetric._calculate_instability_for_each_file')
+    @patch('utils.FileUtility.get_all_code_files')
+    @patch('metrics.instability_metric.InstabilityMetric._create_user_include_matrix')
+    @patch('metrics.instability_metric.InstabilityMetric._add_stl_includes')
+    @patch('metrics.instability_metric.InstabilityMetric._fill_include_matrix')
+    @patch('metrics.instability_metric.InstabilityMetric._calculate_instability_for_each_file')
     def testCorrectFunctionCallsWithNonEmptyFilePath(self, mocked_i_calc_func, mocked_i_fill_func, mocked_i_add_func,
                                                      mocked_i_create_func, mocked_fut_get_func):
         '''

--- a/tests/test_metrics/Test_MainSequence.py
+++ b/tests/test_metrics/Test_MainSequence.py
@@ -7,16 +7,12 @@ import numpy as np
 import pandas as pd
 import unittest
 from unittest.mock import patch
-import sys
 import warnings
 
-# make utility scripts visible
-sys.path.append('scm_modules/utils/')
-import DataSeriesUtility as dsu
-import FileUtility as fut
+import utils.DataSeriesUtility as dsu
+import utils.FileUtility as fut
 
-sys.path.append('scm_modules/metrics/')
-from main_sequence import MainSequence
+from metrics.main_sequence import MainSequence
 
 
 def createUUT():
@@ -333,7 +329,7 @@ class TestMainSequenceDefineMotionAnnotationCallback(unittest.TestCase):
                 mocked_con_func.assert_not_called()
 
     @patch('matplotlib.backend_bases.FigureCanvasBase.mpl_connect')
-    @patch('main_sequence.MainSequence._annotate_point')
+    @patch('metrics.main_sequence.MainSequence._annotate_point')
     def testCallbackConnectionToMotionEvent(self, mocked_ms_anno_func, mocked_con_func):
         '''
         Test that the annotation-callback is correctly connected to Figure.Canvas
@@ -365,11 +361,11 @@ class TestMainSequenceDefineMotionAnnotationCallback(unittest.TestCase):
 
 
 class TestMainSequencePlotMetrics(unittest.TestCase):
-    @patch('DataSeriesUtility.get_instability_and_abstractness_metric')
+    @patch('utils.DataSeriesUtility.get_instability_and_abstractness_metric')
     @patch('matplotlib.axes.Axes.scatter')
     @patch('matplotlib.pyplot.show')
-    @patch('main_sequence.MainSequence._define_motion_annotation_callback')
-    @patch('main_sequence.MainSequence._layout_ax')
+    @patch('metrics.main_sequence.MainSequence._define_motion_annotation_callback')
+    @patch('metrics.main_sequence.MainSequence._layout_ax')
     def testCorrectFunctionCalls(self, mocked_ms_func, mocked_ms_cb_func, mocked_show_func, mocked_scatter_func,
                                  mocked_dsu_func):
         '''
@@ -404,11 +400,11 @@ class TestMainSequencePlotMetrics(unittest.TestCase):
             mocked_ms_cb_func.assert_called_once()
             mocked_show_func.assert_called_once()
 
-    @patch('DataSeriesUtility.get_instability_and_abstractness_metric')
+    @patch('utils.DataSeriesUtility.get_instability_and_abstractness_metric')
     @patch('matplotlib.axes.Axes.scatter')
     @patch('matplotlib.pyplot.show')
-    @patch('main_sequence.MainSequence._define_motion_annotation_callback')
-    @patch('main_sequence.MainSequence._layout_ax')
+    @patch('metrics.main_sequence.MainSequence._define_motion_annotation_callback')
+    @patch('metrics.main_sequence.MainSequence._layout_ax')
     def testCorrectFunctionCallArguments(self, mocked_ms_func, mocked_ms_cb_func, mocked_show_func, mocked_scatter_func,
                                          mocked_dsu_func):
         '''
@@ -450,7 +446,7 @@ class TestMainSequencePlotMetrics(unittest.TestCase):
 
 
 class TestMainSequenceSaveMetrics(unittest.TestCase):
-    @patch('FileUtility.save_metric_to_file')
+    @patch('utils.FileUtility.save_metric_to_file')
     def testCorrectFunctionCallsIfMetricsAreExisting(self, mocked_fut_save_func):
         '''
         Test that correct functions are invoked if metrics are already existing
@@ -474,8 +470,8 @@ class TestMainSequenceSaveMetrics(unittest.TestCase):
                              mocked_fut_save_func(mocked_abs_metric, '')]
                 mocked_fut_save_func.has_calls(call_list)
 
-    @patch('DataSeriesUtility.get_instability_and_abstractness_metric')
-    @patch('FileUtility.save_metric_to_file')
+    @patch('utils.DataSeriesUtility.get_instability_and_abstractness_metric')
+    @patch('utils.FileUtility.save_metric_to_file')
     def testCorrectFunctionCallsIfMetricsNotExisting(self, mocked_fut_save_func, mocked_dsu_get_func):
         '''
         Test that correct functions are invoked if metrics are not existing

--- a/tests/test_utils/Test_DataSeriesUtility.py
+++ b/tests/test_utils/Test_DataSeriesUtility.py
@@ -4,10 +4,10 @@ import unittest
 from unittest.mock import patch
 import sys
 
-sys.path.append('scm_modules/utils/')
+sys.path.append('tests/modules_under_test/utils/')
 import DataSeriesUtility as dsu
 
-sys.path.append('scm_modules/metrics/')
+sys.path.append('tests/modules_under_test/metrics/')
 from instability_metric import InstabilityMetric
 from abstractness_metric import AbstractnessMetric
 

--- a/tests/test_utils/Test_FileUtility.py
+++ b/tests/test_utils/Test_FileUtility.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import warnings
 import sys
 
-sys.path.append('scm_modules/utils/')
+sys.path.append('tests/modules_under_test/utils/')
 import FileUtility as fut
 
 

--- a/tests/test_utils/Test_ProgrammingLanguageConfig.py
+++ b/tests/test_utils/Test_ProgrammingLanguageConfig.py
@@ -1,7 +1,7 @@
 import unittest
 import sys
 
-sys.path.append('scm_modules/utils/')
+sys.path.append('tests/modules_under_test/utils/')
 import ProgrammingLanguageConfig as plc
 import ProgrammingLanguageConstants as plconst
 


### PR DESCRIPTION
This PR closes #17.

Using Python modules instead of sys.path.append(...), this application can now be called from anywhere. However, these changes affected the unit-tests which were not working anymore.

A quick workaround included the full-copying of all Python modules into the tests-folder. Now all unit-tests refer to those copied files. This is, of course, not a reliable solution, but it works for now.

Issue #19 will tackle this and change this workaround into a reliable solution.

