### PR TITLE
improvement/use_general_path_delimiter

### DIFF
--- a/scm_modules/utils/FileUtility.py
+++ b/scm_modules/utils/FileUtility.py
@@ -3,8 +3,6 @@ import glob
 from pathlib import Path
 import warnings
 
-# glob extends paths with \
-PATH_DELIMITER = '\\'
 
 # default directory for saved metric
 DEFAULT_DIRECTORY = 'saved_metrics'
@@ -31,7 +29,7 @@ def get_all_code_files(directory_path, allowed_file_extensions):
 def extract_filename(filepath):
     ''' return solely the filename including the extension '''
     # get last part of file_path
-    filename = filepath.split(PATH_DELIMITER)[-1]
+    filename = Path(filepath).stem
 
     return filename
 

--- a/tests/modules_under_test/utils/FileUtility.py
+++ b/tests/modules_under_test/utils/FileUtility.py
@@ -3,8 +3,6 @@ import glob
 from pathlib import Path
 import warnings
 
-# glob extends paths with \
-PATH_DELIMITER = '\\'
 
 # default directory for saved metric
 DEFAULT_DIRECTORY = 'saved_metrics'
@@ -31,7 +29,7 @@ def get_all_code_files(directory_path, allowed_file_extensions):
 def extract_filename(filepath):
     ''' return solely the filename including the extension '''
     # get last part of file_path
-    filename = filepath.split(PATH_DELIMITER)[-1]
+    filename = Path(filepath).stem
 
     return filename
 

--- a/tests/test_utils/Test_FileUtility.py
+++ b/tests/test_utils/Test_FileUtility.py
@@ -54,21 +54,21 @@ class TestFileUtilityExtractFileName(unittest.TestCase):
         returned_name = fut.extract_filename('')
         self.assertEqual(returned_name, '')
 
-    def testValidFilePath(self):
+    def testValidFilePathWindows(self):
         '''
-        Test that the last element is returned if a valid path is given
+        Test that the last element is returned if a Windows path is given
         '''
-        valid_path = 'valid\\path\\to\\filename'
+        valid_path = 'valid\\path\\to\\filename.py'
         returned_name = fut.extract_filename(valid_path)
         self.assertEqual(returned_name, 'filename')
 
-    def testValidFilePathWrongDelimiter(self):
+    def testValidFilePathUnix(self):
         '''
-        Test that a wrong delimiter does return the whole filepath
+        Test that the last element is returned if a Unix path is given
         '''
-        valid_path_with_wrong_delimiter = 'valid/path/to/filename'
-        returned_name = fut.extract_filename(valid_path_with_wrong_delimiter)
-        self.assertEqual(returned_name, 'valid/path/to/filename')
+        valid_path = 'valid/path/to/filename.py'
+        returned_name = fut.extract_filename(valid_path)
+        self.assertEqual(returned_name, 'filename')
 
 
 class TestFileUtilitySaveMetricToFile(unittest.TestCase):

--- a/tests/test_utils/Test_FileUtility.py
+++ b/tests/test_utils/Test_FileUtility.py
@@ -54,17 +54,9 @@ class TestFileUtilityExtractFileName(unittest.TestCase):
         returned_name = fut.extract_filename('')
         self.assertEqual(returned_name, '')
 
-    def testValidFilePathWindows(self):
+    def testValidFilePath(self):
         '''
-        Test that the last element is returned if a Windows path is given
-        '''
-        valid_path = 'valid\\path\\to\\filename.py'
-        returned_name = fut.extract_filename(valid_path)
-        self.assertEqual(returned_name, 'filename')
-
-    def testValidFilePathUnix(self):
-        '''
-        Test that the last element is returned if a Unix path is given
+        Test that the last element is returned if a valid path is given
         '''
         valid_path = 'valid/path/to/filename.py'
         returned_name = fut.extract_filename(valid_path)


### PR DESCRIPTION
remove Windows path delimiter, use Python Path libs method `.stem` to extract the file name solely